### PR TITLE
ci: pnpm version update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.2
-      - uses: pnpm/action-setup@v3.0.0
+      - uses: actions/checkout@v4.1.3
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: lts/*
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install
+      - uses: pnpm/action-setup@v3.0.0
+        with:
+          version: 9
+          run_install: true
 
       - name: Lint
         run: pnpm run lint
@@ -37,14 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.2
-      - uses: pnpm/action-setup@v3.0.0
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: lts/*
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install
+      - uses: pnpm/action-setup@v3.0.0
+        with:
+          version: 9
+          run_install: true
 
       - name: Build Extension
         run: pnpm build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
           node-version: lts/*
       - uses: pnpm/action-setup@v3.0.0
         with:
-          version: 9
           run_install: true
 
       - name: Lint
@@ -36,13 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.2
+      - uses: pnpm/action-setup@v3.0.0
+        with:
+          run_install: true
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: lts/*
-      - uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 9
-          run_install: true
+          cache: pnpm
 
       - name: Build Extension
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
           node-version: lts/*
       - uses: pnpm/action-setup@v3.0.0
         with:
-          version: 9
           run_install: true
 
       - name: Lint
@@ -25,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.3
+      - uses: pnpm/action-setup@v3.0.0
+        with:
+          run_install: true
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: lts/*
-      - uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 9
-          run_install: true
+          cache: pnpm
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2.4.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v4.1.3
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: lts/*
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install
+      - uses: pnpm/action-setup@v3.0.0
+        with:
+          version: 9
+          run_install: true
 
       - name: Lint
         run: pnpm run lint
@@ -25,15 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2.4.0
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v4.1.3
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: lts/*
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install
+      - uses: pnpm/action-setup@v3.0.0
+        with:
+          version: 9
+          run_install: true
 
       - name: Build
         run: |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "displayName": "BewlyBewly",
   "version": "0.17.0",
   "private": true,
-  "packageManager": "pnpm@8.15.3",
   "description": "Just make a few small changes to your Bilibili homepage.",
   "homepage": "https://github.com/hakadao/BewlyBewly",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "displayName": "BewlyBewly",
   "version": "0.17.0",
   "private": true,
+  "packageManager": "pnpm@9.0.5",
   "description": "Just make a few small changes to your Bilibili homepage.",
   "homepage": "https://github.com/hakadao/BewlyBewly",
   "scripts": {


### PR DESCRIPTION
当本地pnpm版本为9.x，与package.json中的版本不对应时，将无法使用pnpm命令

此问题在本pr中修复
