### PR TITLE
feat(userpanel): Add "我的工房" link to UserPanelPop.vue

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -240,6 +240,7 @@ topbar:
     uploads_manager: 投稿管理
     b_coins_wallet: B币钱包
     orders: 订单中心
+    workshop: 我的工房
     my_stream_info: 直播中心
     my_courses: 我的课程
     log_out: 退出登录

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -243,7 +243,7 @@ topbar:
     uploads_manager: 內容管理
     b_coins_wallet: B幣錢包
     orders: 訂單資訊
-    workshop: 我的工房
+    workshop: 我的工作坊
     my_stream_info: 實況資訊
     my_courses: 我的課程
     log_out: 退出登入

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -243,6 +243,7 @@ topbar:
     uploads_manager: 內容管理
     b_coins_wallet: B幣錢包
     orders: 訂單資訊
+    workshop: 我的工房
     my_stream_info: 實況資訊
     my_courses: 我的課程
     log_out: 退出登入

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -241,6 +241,7 @@ topbar:
     uploads_manager: Uploads manager
     b_coins_wallet: B-coins Wallet
     orders: Orders
+    workshop: My workshop
     my_stream_info: My stream info
     my_courses: My courses
     log_out: Log out

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -243,7 +243,7 @@ topbar:
     uploads_manager: 內容管理
     b_coins_wallet: B銀荷包
     orders: 訂單資訊
-    workshop: 我的工房
+    workshop: 我嘅工作坊
     my_stream_info: 實況資訊
     my_courses: 我嘅課程
     log_out: 登出

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -243,6 +243,7 @@ topbar:
     uploads_manager: 內容管理
     b_coins_wallet: B銀荷包
     orders: 訂單資訊
+    workshop: 我的工房
     my_stream_info: 實況資訊
     my_courses: 我嘅課程
     log_out: 登出

--- a/src/components/TopBar/components/UserPanelPop.vue
+++ b/src/components/TopBar/components/UserPanelPop.vue
@@ -22,6 +22,7 @@ const otherLinks = computed((): { name: string, url: string }[] => {
     { name: t('topbar.user_dropdown.uploads_manager'), url: 'https://member.bilibili.com/v2#/upload-manager/article' },
     { name: t('topbar.user_dropdown.b_coins_wallet'), url: 'https://pay.bilibili.com/' },
     { name: t('topbar.user_dropdown.orders'), url: 'https://show.bilibili.com/orderlist' },
+    { name: t('topbar.user_dropdown.workshop'), url: 'https://gf.bilibili.com?msource=main_station' },
     { name: t('topbar.user_dropdown.my_stream_info'), url: 'https://link.bilibili.com/p/center/index' },
     { name: t('topbar.user_dropdown.my_courses'), url: 'https://www.bilibili.com/cheese/mine/list' },
   ]


### PR DESCRIPTION
In UserPanelPop.vue, I added a new menu item to the 'otherLinks' array for quick access to the "My Workshop（我的工房）" page. The new item is:

{ name: t('topbar.user_dropdown.workshop'), url: 'https://gf.bilibili.com?msource=main_station' }

This update enhances the user experience by providing a direct link to the user's workshop from the user dropdown menu.

I believe many creators will use the "My Workshop（我的工房）" option, which can help them quickly jump to their own workshop（B站工房） page to handle some user orders.
