### PR TITLE
style: add empty line placeholder to video card title

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -57,6 +57,13 @@ html.dark.bewly-design {
   line-break: anywhere;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  min-height: 3em;
+
+  &:after {
+    content: "";
+    display: block;
+    visibility: hidden;
+  }
 }
 
 .bewly-design {


### PR DESCRIPTION
优化了首页视频卡片在只有一行标题时的占位显示，将所有卡片的高度统一，不再有视觉错位

 优化前
![image](https://github.com/BewlyBewly/BewlyBewly/assets/48410934/e7030889-7a96-4d91-9cf8-1fe20808cf6b)

优化后
![image](https://github.com/BewlyBewly/BewlyBewly/assets/48410934/1209fc75-ee03-4e1b-aafa-7713dce1a9d8)
