### PR TITLE
fix(VideoCard): preview control cannot be dragged while pressing

### DIFF
--- a/src/components/VideoCard/VideoCard.vue
+++ b/src/components/VideoCard/VideoCard.vue
@@ -156,6 +156,10 @@ function handleMoreBtnClick(event: MouseEvent) {
 function handleUndo() {
   emit('undo')
 }
+
+function handleVideoClick() {
+  window.open(videoUrl.value, '_blank', 'noopener,noreferrer')
+}
 </script>
 
 <template>
@@ -207,9 +211,9 @@ function handleUndo() {
       bg="hover:$bew-fill-2 active:$bew-fill-3" hover:ring="8 $bew-fill-2" active:ring="8 $bew-fill-3"
       :style="{ contentVisibility }"
     >
-      <a
+      <div
         :style="{ display: horizontal ? 'flex' : 'block', gap: horizontal ? '1.5rem' : '0' }"
-        :href="videoUrl" target="_blank" rel="noopener noreferrer"
+        @click="handleVideoClick"
         @mouseenter="handleMouseEnter"
         @mouseleave="handelMouseLeave"
       >
@@ -458,7 +462,7 @@ function handleUndo() {
             </div>
           </div>
         </div>
-      </a>
+      </div>
     </div>
 
     <!-- skeleton -->


### PR DESCRIPTION
- [x] [CONTRIBUTING](/docs/CONTRIBUTING.md)

经测试，在a标签下的 video controls 无法拖拽，于是换成了div标签

bug如图：

![2297e93cc65060ba03b634a86159447](https://github.com/BewlyBewly/BewlyBewly/assets/40552111/10e80f32-97da-4da5-9747-1406ffeeef60)

