### PR TITLE
feat: Add wheel navigation support for menu items

### DIFF
--- a/src/utils/wheelNavigationChange.ts
+++ b/src/utils/wheelNavigationChange.ts
@@ -1,0 +1,19 @@
+function handleWheelNavigationChange(event: WheelEvent, list: any[], activeItem: string, setActiveItem: (item: any) => void) {
+  event.preventDefault() // 阻止浏览器默认的滚动行为
+  // const currentIndex = list.findIndex(item => item.value === activeItem.value || item.page === activeItem.value)
+  const currentIndex = list.findIndex(item => item.value === activeItem || item.page === activeItem)
+  // console.log(list, currentIndex, activeItem)
+  if (event.deltaY < 0) {
+    // Scroll up
+    const newItem = list[(currentIndex - 1 + list.length) % list.length]
+    // console.log('newItem:', (currentIndex - 1 + list.length) % list.length)
+    setActiveItem(newItem)
+  }
+  else {
+    // Scroll down
+    const newItem = list[(currentIndex + 1) % list.length]
+    // console.log('newItem:', (currentIndex + 1) % list.length)
+    setActiveItem(newItem)
+  }
+}
+export default handleWheelNavigationChange


### PR DESCRIPTION
## 新增通过鼠标滚轮切换菜单项的功能

### 功能描述
现在用户可以通过鼠标滚轮在菜单的各项之间进行切换。

https://github.com/BewlyBewly/BewlyBewly/assets/110297461/08620c61-96ec-4198-9371-6c5b569a6021

支持的菜单：
![支持菜单](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/0e0bca37-ab5a-4136-92ff-3122ed5d53ea)

### 更改内容
- 新增 `handleWheelNavigationChange` 通用函数，用于处理鼠标滚轮事件。

### Bug
在测试过程中，发现了以下两个 Bug：

1. **加载动画问题**：
   切换回“个性推荐”时，右上角会一直显示加载动画，即使页面不需要加载。
   经测试，该 Bug 并非本次 PR 产生，之前版本中已存在该问题。
   Bug 演示：

https://github.com/BewlyBewly/BewlyBewly/assets/110297461/7f45c2af-cf23-44e4-840b-3da572029c12

2. **标签栏隐藏后无法切换**：
   标签栏隐藏再显示后，将无法通过滚轮切换标签。
   该问题影响较小，暂不修复。
