### PR TITLE
fix: userSpace page style

### DIFF
--- a/src/styles/adaptedStyles/userSpacePage.scss
+++ b/src/styles/adaptedStyles/userSpacePage.scss
@@ -481,6 +481,7 @@
       #page-fav .fav-main .fav-action-bottom li,
       .sub-tabs span,
       #page-follows .follow-tabs,
+      #page-index .col-2 .section .user-auth .profession-description,
       .elec .elec-count,
       #page-index .col-2 .section .user-auth .auth-description,
       #page-series-index .channel-item .channel-name,
@@ -589,6 +590,10 @@
     #page-index .col-2 .section,
     #page-dynamic .col-2 .section {
       background-color: var(--bew-content-solid-1);
+    }
+
+    .elec .new-elec-trigger:hover {
+      background-color: rgb(65 31 39);
     }
 
     .be-dropdown-item:hover,

--- a/src/styles/adaptedStyles/userSpacePage.scss
+++ b/src/styles/adaptedStyles/userSpacePage.scss
@@ -53,6 +53,7 @@
     .n .n-data.router-link-active .n-data-v,
     .wrapper .edit-video-modal .target-favlist .target-favitem:hover .target-fav-title .fav-meta .fav-name,
     .i-live .i-live-off-guest a,
+    .modal-wrapper .modal-header-close:hover,
     a:hover,
     #page-index .channel .section-right-options .play-all-channel:hover .video-commonplayer_play,
     #page-follows .follow-tabs span.active,

--- a/src/styles/adaptedStyles/userSpacePage.scss
+++ b/src/styles/adaptedStyles/userSpacePage.scss
@@ -52,6 +52,7 @@
     .n .n-data.router-link-active .n-data-k,
     .n .n-data.router-link-active .n-data-v,
     .wrapper .edit-video-modal .target-favlist .target-favitem:hover .target-fav-title .fav-meta .fav-name,
+    .i-live .i-live-off-guest a,
     a:hover,
     #page-index .channel .section-right-options .play-all-channel:hover .video-commonplayer_play,
     #page-follows .follow-tabs span.active,


### PR DESCRIPTION
修复用户空间页介绍和充电按钮`:hover`样式
### 对比
修改后(左), 修改前(右)
![PixPin_2024-06-12_19-04-34](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/7ebe9fca-0862-44d9-835c-f6771dde373f)

### 其他
我发现在未登录时, 有一些组件样式与主题不符, 这个要修复吗?
比如已经发现的:
![PixPin_2024-06-12_19-04-34](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/d1b5b0bf-07d4-4c97-9683-4243cee9dd4d)
![PixPin_2024-06-12_19-14-23](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/3fffeaea-b391-40a6-bdb1-f1aa83b65ae2)
![PixPin_2024-06-12_19-14-37](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/4853bbe3-5a60-4c8a-b7b6-8e3b6b21f5cd)
