### PR TITLE
fix videoPage comment button disable dark style

### DIFF
--- a/src/styles/adaptedStyles/comments.scss
+++ b/src/styles/adaptedStyles/comments.scss
@@ -272,10 +272,6 @@
       border-color: var(--bew-border-color);
     }
 
-    .reply-operation .operation-list {
-      box-shadow: 0 0 5px #5553;
-    }
-
     .bb-comment .comment-send .comment-emoji,
     .comment-bilibili-fold .comment-send .comment-emoji,
     .bb-comment .comment-send-lite .comment-emoji,

--- a/src/styles/adaptedStyles/comments.scss
+++ b/src/styles/adaptedStyles/comments.scss
@@ -272,6 +272,10 @@
       border-color: var(--bew-border-color);
     }
 
+    .reply-operation .operation-list {
+      box-shadow: 0 0 5px #5553;
+    }
+
     .bb-comment .comment-send .comment-emoji,
     .comment-bilibili-fold .comment-send .comment-emoji,
     .bb-comment .comment-send-lite .comment-emoji,

--- a/src/styles/adaptedStyles/videoPage.scss
+++ b/src/styles/adaptedStyles/videoPage.scss
@@ -50,6 +50,7 @@
       background-color: var(--bew-theme-color-10);
     }
 
+    .video-sections-v1 .video-sections-head_first-line .first-line-left .first-line-title:hover,
     .note-detail .note-operation .tab-action-item.is-active .tab-icon {
       color: var(--bew-theme-color);
     }
@@ -195,6 +196,10 @@
 
     .note-list .note-card-container .note-card,
     .resizable-component .ql-tag-blot .time-tag-item,
+    .ql-toolbar {
+      background-color: var(--bew-fill-1);
+    }
+
     .bpx-player-container[data-revision="1"]
       .bpx-player-sending-bar
       .bpx-player-video-inputbar
@@ -206,9 +211,8 @@
       .bpx-player-dm-btn-send.bui-disabled
       .bui-button-blue
       .modal-wrapper
-      .modal-header-close:hover,
-    .ql-toolbar {
-      background-color: var(--bew-fill-1);
+      .modal-header-close:hover {
+      background-color: var(--bew-fill-3);
     }
 
     .note-pc .note-container,

--- a/src/styles/adaptedStyles/videoPage.scss
+++ b/src/styles/adaptedStyles/videoPage.scss
@@ -195,6 +195,18 @@
 
     .note-list .note-card-container .note-card,
     .resizable-component .ql-tag-blot .time-tag-item,
+    .bpx-player-container[data-revision="1"]
+      .bpx-player-sending-bar
+      .bpx-player-video-inputbar
+      .bpx-player-dm-btn-send.bui-disabled
+      .bui-button-blue,
+    .bpx-player-container[data-revision="2"]
+      .bpx-player-sending-bar
+      .bpx-player-video-inputbar
+      .bpx-player-dm-btn-send.bui-disabled
+      .bui-button-blue
+      .modal-wrapper
+      .modal-header-close:hover,
     .ql-toolbar {
       background-color: var(--bew-fill-1);
     }


### PR DESCRIPTION
1. 修复视频页评论按钮暗色主题下禁用时的样式
[
![PixPin_2024-06-12_20-38-04](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/f3a9fd36-f6c9-4385-8071-4411efaa60ee)
](url)
示例: www.bilibili.com/video/BV1UM4m1k7PX
2. 为评论区黑暗主题下适配阴影
![PixPin_2024-06-12_20-38-17](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/45713854-aff5-4e40-8b1e-6d398b2099f0)
