### PR TITLE
fix: reply show in dark mode

### DIFF
--- a/src/styles/adaptedStyles/comments.scss
+++ b/src/styles/adaptedStyles/comments.scss
@@ -303,6 +303,22 @@
       border-color: var(--Ye1);
       color: var(--Or7);
     }
+
+    // .show-reply
+    .sub-reply-item.show-reply,
+    .reply-item .root-reply-container.show-reply {
+      background-color: var(--bew-content-solid-1-hover);
+      animation-name: enterAnimation-jumpReply;
+    }
+
+    @keyframes enterAnimation-jumpReply {
+      0% {
+        background-color: var(--bew-content-solid-1-hover);
+      }
+      100% {
+        background-color: #dff6fb00;
+      }
+    }
   }
   // #endregion
 }


### PR DESCRIPTION
- [x] [CONTRIBUTING](/docs/CONTRIBUTING.md)

由链接后#参数定位回复，或从消息通知点进回复时，若在夜间模式，会出现如图一的过亮背景，故修改。

![bef](https://github.com/BewlyBewly/BewlyBewly/assets/144692181/4e00d7d1-8443-436b-8f79-b900231d0ef6)
![aft](https://github.com/BewlyBewly/BewlyBewly/assets/144692181/95c81118-5bc4-4b8a-b5f4-37faf9e2819d)
