### PR TITLE
feat: Add styles support for articles list page and articles ranking page

### DIFF
--- a/src/styles/adaptedStyles/articlesListPage.scss
+++ b/src/styles/adaptedStyles/articlesListPage.scss
@@ -1,0 +1,74 @@
+.bewly-design.articlesListPage {
+  // #region theme color adaption part
+  // Increase the priority of the style inside by writing a non-existent selector in `:not()`
+  :not(fdjslfds) {
+    .list-container .article-list-block .article-item .item-holder .article-content:hover .article-title,
+    .list-container
+      .article-list-block
+      .article-item
+      .item-holder
+      .article-content
+      .article-left-block
+      .article-info-bar
+      .reply:hover {
+      color: var(--bew-theme-color);
+    }
+
+    .error-container .error-panel .rollback-btn,
+    .error-container .error-manga .change-img-btn,
+    .list-container .list-info-block .right-side .up-info-block .follow-btn:not(.on),
+    .modalBox .sure {
+      background-color: var(--bew-theme-color);
+    }
+  }
+  // #endregion
+
+  // #region dark mode adaption part
+  &.dark {
+    .list-container .list-info-block .right-side .title,
+    .list-container .list-info-block .right-side .up-info-block .up-name,
+    .list-container .article-list-block .article-item .item-holder .article-content .article-title,
+    .modalBox,
+    .modalBox .cancel {
+      color: var(--bew-text-1);
+    }
+
+    .list-container .list-info-block .right-side .col,
+    .list-container .list-info-block .right-side .summary,
+    .list-container .list-info-block .right-side .up-info-block .follow-btn.on {
+      color: var(--bew-text-2);
+    }
+
+    .error-container .error-panel,
+    .error-container .error-split,
+    .error-container .error-manga,
+    .list-container .list-info-block,
+    .list-container .article-list-block,
+    .list-container .article-list-block .article-item {
+      background-color: var(--bew-bg);
+    }
+
+    .modalBox {
+      background-color: var(--bew-content-solid-1);
+    }
+
+    .list-container .list-info-block .right-side .col .split-line {
+      background-color: var(--bew-border-color);
+    }
+
+    .list-container .list-info-block .right-side .up-info-block .follow-btn.on {
+      background-color: var(--bew-fill-1);
+    }
+
+    .modalBox .cancel {
+      background-color: var(--bew-fill-2);
+    }
+
+    .list-container .list-info-block .right-side .up-info-block .follow-btn.on,
+    .list-container .article-list-block .article-item .item-holder .article-content .article-left-block,
+    .modalBox .cancel {
+      border-color: var(--bew-border-color);
+    }
+  }
+  // #endregion
+}

--- a/src/styles/adaptedStyles/articlesListPage.scss
+++ b/src/styles/adaptedStyles/articlesListPage.scss
@@ -56,12 +56,9 @@
       background-color: var(--bew-border-color);
     }
 
-    .list-container .list-info-block .right-side .up-info-block .follow-btn.on {
-      background-color: var(--bew-fill-1);
-    }
-
+    .list-container .list-info-block .right-side .up-info-block .follow-btn.on,
     .modalBox .cancel {
-      background-color: var(--bew-fill-2);
+      background-color: var(--bew-fill-1);
     }
 
     .list-container .list-info-block .right-side .up-info-block .follow-btn.on,

--- a/src/styles/adaptedStyles/articlesPage.scss
+++ b/src/styles/adaptedStyles/articlesPage.scss
@@ -39,7 +39,8 @@
     .normal-article-holder a,
     .read-article-holder .card-text-label,
     .share-dynamic-dialog .sdd-card .name,
-    .bili-dialog-bomb .appeal-box .wrap .container .textarea .memo a {
+    .bili-dialog-bomb .appeal-box .wrap .container .textarea .memo a,
+    .article-tags .tag-item:hover {
       color: var(--bew-theme-color);
     }
 

--- a/src/styles/adaptedStyles/articlesRankingPage.scss
+++ b/src/styles/adaptedStyles/articlesRankingPage.scss
@@ -1,0 +1,51 @@
+.bewly-design.articlesRankingPage {
+  // #region theme color adaption part
+  // Increase the priority of the style inside by writing a non-existent selector in `:not()`
+  :not(fdjslfds) {
+    #App .rank-module .tab-bar .tab-item.on,
+    #App .rank-module .tab-bar .tab-item:hover,
+    #App .rank-module .article-list .article-item .item-holder .article-content:hover .article-title,
+    #App
+      .rank-module
+      .article-list
+      .article-item
+      .item-holder
+      .article-content
+      .article-left-block
+      .article-info-bar
+      .reply:hover,
+    #App .rank-module .article-list .article-item .item-holder .score-module .score {
+      color: var(--bew-theme-color);
+    }
+
+    #App .rank-module .tips {
+      background-color: var(--bew-theme-color-20);
+    }
+
+    #App .rank-module .tab-bar .tab-item.on {
+      border-color: var(--bew-theme-color);
+    }
+  }
+  // #endregion
+
+  // #region dark mode adaption part
+  &.dark {
+    #App,
+    #App .rank-module .article-list .article-item .item-holder .article-content .article-title {
+      color: var(--bew-text-1);
+    }
+
+    #App .rank-module .tips {
+      color: var(--bew-text-2);
+    }
+
+    #App .rank-module .article-list .article-item {
+      background-color: var(--bew-bg);
+    }
+
+    #App .rank-module .article-list .article-item .item-holder .article-content {
+      border-color: var(--bew-border-color);
+    }
+  }
+  // #endregion
+}

--- a/src/styles/adaptedStyles/articlesRankingPage.scss
+++ b/src/styles/adaptedStyles/articlesRankingPage.scss
@@ -18,10 +18,6 @@
       color: var(--bew-theme-color);
     }
 
-    #App .rank-module .tips {
-      background-color: var(--bew-theme-color-20);
-    }
-
     #App .rank-module .tab-bar .tab-item.on {
       border-color: var(--bew-theme-color);
     }
@@ -37,6 +33,10 @@
 
     #App .rank-module .tips {
       color: var(--bew-text-2);
+    }
+
+    #App .rank-module .tips {
+      background-color: var(--bew-fill-1);
     }
 
     #App .rank-module .article-list .article-item {

--- a/src/styles/adaptedStyles/index.ts
+++ b/src/styles/adaptedStyles/index.ts
@@ -98,6 +98,18 @@ async function setupStyles() {
     document.documentElement.classList.add('channelPage')
   }
 
+  // articles list page 专栏列表页
+  else if (/https?:\/\/(?:www\.)?bilibili\.com\/read\/readlist.*/.test(currentUrl)) {
+    await import('./articlesListPage.scss')
+    document.documentElement.classList.add('articlesListPage')
+  }
+
+  // articles ranking page 专栏排行榜页
+  else if (/https?:\/\/(?:www\.)?bilibili\.com\/read\/ranking.*/.test(currentUrl)) {
+    await import('./articlesRankingPage.scss')
+    document.documentElement.classList.add('articlesRankingPage')
+  }
+
   // articles page 专栏页
   else if (/https?:\/\/(?:www\.)?bilibili\.com\/read.*/.test(currentUrl)) {
     await import('./articlesPage.scss')

--- a/src/styles/adaptedStyles/index.ts
+++ b/src/styles/adaptedStyles/index.ts
@@ -98,6 +98,12 @@ async function setupStyles() {
     document.documentElement.classList.add('channelPage')
   }
 
+  // articles page 专栏页
+  else if (/https?:\/\/(?:www\.)?bilibili\.com\/read.*/.test(currentUrl)) {
+    await import('./articlesPage.scss')
+    document.documentElement.classList.add('articlesPage')
+  }
+
   // articles list page 专栏列表页
   else if (/https?:\/\/(?:www\.)?bilibili\.com\/read\/readlist.*/.test(currentUrl)) {
     await import('./articlesListPage.scss')
@@ -108,12 +114,6 @@ async function setupStyles() {
   else if (/https?:\/\/(?:www\.)?bilibili\.com\/read\/ranking.*/.test(currentUrl)) {
     await import('./articlesRankingPage.scss')
     document.documentElement.classList.add('articlesRankingPage')
-  }
-
-  // articles page 专栏页
-  else if (/https?:\/\/(?:www\.)?bilibili\.com\/read.*/.test(currentUrl)) {
-    await import('./articlesPage.scss')
-    document.documentElement.classList.add('articlesPage')
   }
 
   // 404 page 404页


### PR DESCRIPTION
添加`专栏列表页`和`专栏排行榜页`样式支持

1. 专栏列表页:
示例: www.bilibili.com/read/readlist/rl532802
![PixPin_2024-06-16_16-36-01](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/0f571dbb-29c5-4038-bd4a-e4e1fa90cf20)

2. 专栏排行榜页:
示例: www.bilibili.com/read/ranking#type=3
![PixPin_2024-06-16_16-35-10](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/40cdd386-0ec2-4c5d-ba8b-69b3ec5229c6)

### 修复
修复专栏页文章标签`:hover`样式
![PixPin_2024-06-16_16-39-03](https://github.com/BewlyBewly/BewlyBewly/assets/110297461/457f20be-1115-4071-a311-11888de3dbe6)
