### PR TITLE
fix:创作者中心顶栏修复

### DIFF
--- a/src/styles/adaptedStyles/creativeCenterPage.scss
+++ b/src/styles/adaptedStyles/creativeCenterPage.scss
@@ -1,4 +1,8 @@
 .bewly-design.creativeCenterPage {
+  // 隐藏原版顶栏
+  #app .cc-header {
+    display: none;
+  }
   // #region theme color adaption part
   // Increase the priority of the style inside by writing a non-existent selector in `:not()`
   :not(foobar) {


### PR DESCRIPTION
- [x] [CONTRIBUTING](/docs/CONTRIBUTING.md)

修改：隐藏原版顶栏，正常显示本插件顶栏

- 附图：
    -  v0.25 中的效果
    
    ![image](https://github.com/user-attachments/assets/2cb7dadb-8e24-4ce2-a1ef-3e52a7d3ae62)
    
    - 修改后效果
    
    ![image](https://github.com/user-attachments/assets/4a9bb3e0-fbf1-4bc4-ba12-ac2ce6641f2a)

