### PR TITLE
feat: add web-ext to develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,13 @@
   },
   "lint-staged": {
     "*": "eslint --fix"
+  },
+  "webExt": {
+    "sourceDir": "extension",
+    "run": {
+      "startUrl": [
+        "https://www.bilibili.com/"
+      ]
+    }
   }
 }


### PR DESCRIPTION
哈喽，大佬！

引用 contribute.md 里的一句话 `每次修改后，您需要单击 [Reload Extensions](https://chromewebstore.google.com/detail/extensions-reloader/fimgfedafeadlieiabdeeaodndnlbhid) 按钮并刷新页面以确保应用更改。`

所以说这样的开发体验其实并没有那么好，然后我在之前给 [refined-github](https://github.com/refined-github/refined-github) 贡献的时候，发现它使用了一个库 [web-ext](https://github.com/mozilla/web-ext), 使用了这个库之后，它会打开一个网页加载了项目开发的插件，监听到插件发生了修改之后会自动在打开的网页重新加载插件，我们就不需要在每次修改之后去扩展程序里点击 reload 了。

如果你感兴趣可以看一下压缩包里的视频，我觉得这样开发效率会比之前高！

👇 是视频，文件太大了只能传压缩包

[Area.mp4.zip](https://github.com/user-attachments/files/16397883/Area.mp4.zip)
