### PR TITLE
fix(favorites-popup): fix sidebar spacing issue caused by scroll bar

### DIFF
--- a/src/components/TopBar/components/FavoritesPop.vue
+++ b/src/components/TopBar/components/FavoritesPop.vue
@@ -180,7 +180,7 @@ defineExpose({
 
     <main flex="~" overflow-hidden rounded="$bew-radius">
       <aside
-        w="120px" h="430px" overflow="y-scroll" rounded="l-$bew-radius"
+        w="120px" h="430px" overflow="y-auto" rounded="l-$bew-radius"
         flex="shrink-0" bg="$bew-fill-1"
       >
         <ul grid="~ cols-1">


### PR DESCRIPTION
在收藏的侧边栏那里有一段空白，我觉得就是设置了 `overflow-y: scroll`， 它默认先给了一个滚动条的宽度占据在那里，但是现在并没有出现滚动条，这个 PR 就是修复了这个问题，然后测试了当收藏夹很多需要滚动的时候，样式也没有出现问题。一切运行良好！

before:

<img width="490" alt="image" src="https://github.com/user-attachments/assets/9a4bbb12-c092-4e90-aa20-91fddb321d18">

after:

<img width="467" alt="image" src="https://github.com/user-attachments/assets/1c6bbe91-dc8c-45bd-b499-8828a652a1c5">

<img width="458" alt="image" src="https://github.com/user-attachments/assets/55258058-08b8-4748-8892-9704f491386f">

