### PR TITLE
fix(adapted-styles): fix comments background style

### DIFF
--- a/src/styles/adaptedStyles/common/comments.scss
+++ b/src/styles/adaptedStyles/common/comments.scss
@@ -245,7 +245,8 @@
       background-color: var(--bew-content-solid);
     }
 
-    .forw-area {
+    .forw-area,
+    .bili-rich-textarea__inner {
       background-color: transparent;
     }
 
@@ -329,6 +330,10 @@
       background-color: var(--Ye1);
       border-color: var(--Ye1);
       color: var(--Or7);
+    }
+
+    .bili-rich-textarea::-webkit-scrollbar-thumb {
+      background-color: rgba(120, 120, 140, 0.44);
     }
   }
   // #endregion

--- a/src/styles/adaptedStyles/pages/momentsPage.scss
+++ b/src/styles/adaptedStyles/pages/momentsPage.scss
@@ -249,12 +249,8 @@
       background-color: var(--bew-content-solid);
     }
 
-    .bili-rich-textarea__inner {
-      background-color: transparent;
-      color: var(--bew-text-1);
-    }
-
     .bili-dyn-my-info__stat__item__count,
+    .bili-rich-textarea__inner,
     .bili-rich-text__content,
     .topic-panel__nav-title,
     .relevant-topic__title,

--- a/src/styles/adaptedStyles/pages/topicPage.scss
+++ b/src/styles/adaptedStyles/pages/topicPage.scss
@@ -44,10 +44,6 @@
       background-color: var(--bew-content-solid);
     }
 
-    .bili-rich-textarea__inner {
-      background-color: transparent;
-    }
-
     .active-card .active-content__desc {
       color: var(--bew-text-1);
     }

--- a/src/styles/adaptedStyles/pages/userSpacePage.scss
+++ b/src/styles/adaptedStyles/pages/userSpacePage.scss
@@ -220,7 +220,8 @@
       background-color: var(--bew-theme-color-10);
     }
 
-    .bili-topic-new__default__create__icon {
+    .bili-topic-new__default__create__icon,
+    .bili-topic-selector__bulletin__clear {
       background-color: var(--bew-theme-color-20);
     }
 

--- a/src/styles/adaptedStyles/pages/userSpacePage.scss
+++ b/src/styles/adaptedStyles/pages/userSpacePage.scss
@@ -626,7 +626,9 @@
     .follow-dialog-wrap .follow-dialog-window,
     .follow-dialog-wrap .follow-dialog-window .title,
     .follow-dialog-wrap .follow-dialog-window .content,
-    .bili-at-popup__user--selected {
+    .bili-at-popup__user--selected,
+    .bili-emoji__pkg:not(.active):hover,
+    .bili-emoji__list__item:hover {
       background-color: var(--bew-elevated-solid);
     }
 
@@ -734,7 +736,8 @@
     .emoji-box.bottom:before,
     .btn-container .btn,
     .follow-dialog-wrap .follow-dialog-window .content .group-list ul .follow-group-mask,
-    .comment-bilibili-con .btn .btn-cancel {
+    .comment-bilibili-con .btn .btn-cancel,
+    .bili-dyn-forward-publishing__tools__item.emoji {
       background: unset;
     }
 

--- a/src/styles/adaptedStyles/pages/userSpacePage.scss
+++ b/src/styles/adaptedStyles/pages/userSpacePage.scss
@@ -687,7 +687,8 @@
       background-color: var(--bew-fill-2);
     }
 
-    #page-setting #setting-new-tag-btn {
+    #page-setting #setting-new-tag-btn,
+    .bili-dyn-forward-publishing__editor {
       background: var(--bew-content-solid);
     }
 


### PR DESCRIPTION
<!-- 這裏沒有要求一定要用英文寫 pr 或英文寫註釋, 只要要求會看就可以了, 哪怕用翻譯來看也好 -->
<!-- 裏面的英文註釋沒有必要一定要翻譯成中文之後再提交份 pr (這樣真的沒有任何意義), 英文應該是開發者一定要有所瞭解而不是可有可無的技能, 甚至英文好對人的長遠發展也有幫助 -->
<!-- 如果你的 pr 只是翻譯了某個沒有甚麼內容的 markdown 英文成中文, 爲何開發時不試試瞭解一些英文減少對接觸新知識的阻礙呢? -->
[CONTRIBUTING](/docs/CONTRIBUTING.md)
### 剩余已知问题
![PixPin_2024-07-31_22-58-37](https://github.com/user-attachments/assets/65a9fe8a-1b6d-4795-a89f-537d41dca46d)
设置 `background: unset` 会导致下层多余内容被显示:
![PixPin_2024-07-31_22-58-55](https://github.com/user-attachments/assets/99a8c2f5-7797-4562-b4bd-da076478da04)
也许要设置具体颜色值才能解决?