### PR TITLE
fix: add bilibili icon font to font stack

### DIFF
--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -2,7 +2,7 @@
 
 :root,
 :host {
-  --bew-fonts-basic: bilifont, -apple-system, BlinkMacSystemFont, Inter, "Segoe UI Variable", "Segoe UI", "Roboto Flex", 
+  --bew-fonts-basic: bilifont, -apple-system, BlinkMacSystemFont, Inter, "Segoe UI Variable", "Segoe UI", "Roboto Flex",
     Roboto, "Noto Sans", Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue";
   --bew-fonts-fallback: system-ui, Arial, sans-serif;
 

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -2,8 +2,8 @@
 
 :root,
 :host {
-  --bew-fonts-basic: -apple-system, BlinkMacSystemFont, Inter, "Segoe UI Variable", "Segoe UI", "Roboto Flex", Roboto,
-    "Noto Sans", Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue";
+  --bew-fonts-basic: bilifont, -apple-system, BlinkMacSystemFont, Inter, "Segoe UI Variable", "Segoe UI", "Roboto Flex", 
+    Roboto, "Noto Sans", Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue";
   --bew-fonts-fallback: system-ui, Arial, sans-serif;
 
   --bew-fonts-english: var(--bew-fonts-basic), var(--bew-fonts-fallback);


### PR DESCRIPTION
<!-- see: https://github.com/BewlyBewly/BewlyBewly/blob/main/docs/CONTRIBUTING.md -->

Bilibili have some glyphs in PUA, if here's no `bilifont`, it won't show up:

![image](https://github.com/user-attachments/assets/cd16edbd-04da-4fba-87d7-8ad372e954a7)

expected: 

![image](https://github.com/user-attachments/assets/7d6ecb3c-9659-4df6-908d-9f8e7d5dfd92)

