### PR TITLE
Fix the font blur issue

### DIFF
--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -122,53 +122,53 @@ function setCurrentTitle() {
         :class="{ group: !settings.touchScreenOptimization }"
         shrink-0 p="x-4" pos="absolute left--84px" z-2
       >
-      <ul
-        style="
-          --un-shadow: var(--bew-shadow-4), var(--bew-shadow-edge-glow-2);
-          position: relative;
-        "
-        flex="~ gap-2 col" rounded="30px group-hover:25px" p-2 shadow
-        bg="$bew-content-alt group-hover:$bew-elevated dark:$bew-elevated dark-group-hover:$bew-elevated"
-        scale="group-hover:105" duration-300 overflow-hidden antialiased transform-gpu
-        border="1 $bew-border-color"
-      >
-        <style scoped>
-          ul::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: inherit;
-            z-index: -1;
-            backdrop-filter: var(--bew-filter-glass-2);
-            pointer-events: none;
-          }
-        </style>
-      
-        <li v-for="menuItem in settingsMenuItems" :key="menuItem.value">
-          
-            cursor-pointer w="40px group-hover:180px" h-40px
-            rounded-30px flex items-center overflow-x-hidden
-            duration-300 bg="hover:$bew-fill-2"
-            :class="{ 'menu-item-activated': menuItem.value === activatedMenuItem }"
-            @click="changeMenuItem(menuItem.value)"
-          >
-            <div
-              v-show="menuItem.value !== activatedMenuItem"
-              text="xl center" w-40px h-20px flex="~ shrink-0" justify-center
-              :class="menuItem.icon"
-            />
-            <div
-              v-show="menuItem.value === activatedMenuItem"
-              text="xl center" w-40px h-20px flex="~ shrink-0" justify-center
-              :class="menuItem.iconActivated"
-            />
-            <span shrink-0>{{ menuItem.title }}</span>
-          </a>
-        </li>
-      </ul>
+        <ul
+          style="
+            --un-shadow: var(--bew-shadow-4), var(--bew-shadow-edge-glow-2);
+            position: relative;
+          "
+          flex="~ gap-2 col" rounded="30px group-hover:25px" p-2 shadow
+          bg="$bew-content-alt group-hover:$bew-elevated dark:$bew-elevated dark-group-hover:$bew-elevated"
+          scale="group-hover:105" duration-300 overflow-hidden antialiased transform-gpu
+          border="1 $bew-border-color"
+        >
+          <style scoped>
+            ul::before {
+              content: '';
+              position: absolute;
+              top: 0;
+              left: 0;
+              width: 100%;
+              height: 100%;
+              background: inherit;
+              z-index: -1;
+              backdrop-filter: var(--bew-filter-glass-2);
+              pointer-events: none;
+            }
+          </style>
+
+          <li v-for="menuItem in settingsMenuItems" :key="menuItem.value">
+            <a
+              cursor-pointer w="40px group-hover:180px" h-40px
+              rounded-30px flex items-center overflow-x-hidden
+              duration-300 bg="hover:$bew-fill-2"
+              :class="{ 'menu-item-activated': menuItem.value === activatedMenuItem }"
+              @click="changeMenuItem(menuItem.value)"
+            >
+              <div
+                v-show="menuItem.value !== activatedMenuItem"
+                text="xl center" w-40px h-20px flex="~ shrink-0" justify-center
+                :class="menuItem.icon"
+              />
+              <div
+                v-show="menuItem.value === activatedMenuItem"
+                text="xl center" w-40px h-20px flex="~ shrink-0" justify-center
+                :class="menuItem.iconActivated"
+              />
+              <span shrink-0>{{ menuItem.title }}</span>
+            </a>
+          </li>
+        </ul>
       </aside>
 
       <div

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -125,7 +125,8 @@ function setCurrentTitle() {
         <ul
           style="
             --un-shadow: var(--bew-shadow-4), var(--bew-shadow-edge-glow-2);
-            backdrop-filter: var(--bew-filter-glass-2);
+            /*删除filter-glass，可以让侧边栏文字变得清晰*/
+            /*backdrop-filter: var(--bew-filter-glass-2);*/
           "
           flex="~ gap-2 col" rounded="30px group-hover:25px" p-2 shadow
           bg="$bew-content-alt group-hover:$bew-elevated dark:$bew-elevated dark-group-hover:$bew-elevated"

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -123,6 +123,7 @@ function setCurrentTitle() {
         shrink-0 p="x-4" pos="absolute left--84px" z-2
       >
         <ul
+          relative
           style="
             --un-shadow: var(--bew-shadow-4), var(--bew-shadow-edge-glow-2);
             /*删除filter-glass，可以让侧边栏文字变得清晰*/
@@ -133,6 +134,16 @@ function setCurrentTitle() {
           scale="group-hover:105" duration-300 overflow-hidden antialiased transform-gpu
           border="1 $bew-border-color"
         >
+          /*添加一个div，用来模糊背景*/
+          <div 
+            absolute 
+            inset-0 
+            style="
+              backdrop-filter: var(--bew-filter-glass-2);
+              z-index: -1;
+            "
+          ></div>
+
           <li v-for="menuItem in settingsMenuItems" :key="menuItem.value">
             <a
               cursor-pointer w="40px group-hover:180px" h-40px

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -122,50 +122,53 @@ function setCurrentTitle() {
         :class="{ group: !settings.touchScreenOptimization }"
         shrink-0 p="x-4" pos="absolute left--84px" z-2
       >
-        <ul
-          relative
-          style="
-            --un-shadow: var(--bew-shadow-4), var(--bew-shadow-edge-glow-2);
-            /*删除filter-glass，可以让侧边栏文字变得清晰*/
-            /*backdrop-filter: var(--bew-filter-glass-2);*/
-          "
-          flex="~ gap-2 col" rounded="30px group-hover:25px" p-2 shadow
-          bg="$bew-content-alt group-hover:$bew-elevated dark:$bew-elevated dark-group-hover:$bew-elevated"
-          scale="group-hover:105" duration-300 overflow-hidden antialiased transform-gpu
-          border="1 $bew-border-color"
-        >
-          /*添加一个div，用来模糊背景*/
-          <div 
-            absolute 
-            inset-0 
-            style="
-              backdrop-filter: var(--bew-filter-glass-2);
-              z-index: -1;
-            "
-          ></div>
-
-          <li v-for="menuItem in settingsMenuItems" :key="menuItem.value">
-            <a
-              cursor-pointer w="40px group-hover:180px" h-40px
-              rounded-30px flex items-center overflow-x-hidden
-              duration-300 bg="hover:$bew-fill-2"
-              :class="{ 'menu-item-activated': menuItem.value === activatedMenuItem }"
-              @click="changeMenuItem(menuItem.value)"
-            >
-              <div
-                v-show="menuItem.value !== activatedMenuItem"
-                text="xl center" w-40px h-20px flex="~ shrink-0" justify-center
-                :class="menuItem.icon"
-              />
-              <div
-                v-show="menuItem.value === activatedMenuItem"
-                text="xl center" w-40px h-20px flex="~ shrink-0" justify-center
-                :class="menuItem.iconActivated"
-              />
-              <span shrink-0>{{ menuItem.title }}</span>
-            </a>
-          </li>
-        </ul>
+      <ul
+        style="
+          --un-shadow: var(--bew-shadow-4), var(--bew-shadow-edge-glow-2);
+          position: relative;
+        "
+        flex="~ gap-2 col" rounded="30px group-hover:25px" p-2 shadow
+        bg="$bew-content-alt group-hover:$bew-elevated dark:$bew-elevated dark-group-hover:$bew-elevated"
+        scale="group-hover:105" duration-300 overflow-hidden antialiased transform-gpu
+        border="1 $bew-border-color"
+      >
+        <style scoped>
+          ul::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: inherit;
+            z-index: -1;
+            backdrop-filter: var(--bew-filter-glass-2);
+            pointer-events: none;
+          }
+        </style>
+      
+        <li v-for="menuItem in settingsMenuItems" :key="menuItem.value">
+          
+            cursor-pointer w="40px group-hover:180px" h-40px
+            rounded-30px flex items-center overflow-x-hidden
+            duration-300 bg="hover:$bew-fill-2"
+            :class="{ 'menu-item-activated': menuItem.value === activatedMenuItem }"
+            @click="changeMenuItem(menuItem.value)"
+          >
+            <div
+              v-show="menuItem.value !== activatedMenuItem"
+              text="xl center" w-40px h-20px flex="~ shrink-0" justify-center
+              :class="menuItem.icon"
+            />
+            <div
+              v-show="menuItem.value === activatedMenuItem"
+              text="xl center" w-40px h-20px flex="~ shrink-0" justify-center
+              :class="menuItem.iconActivated"
+            />
+            <span shrink-0>{{ menuItem.title }}</span>
+          </a>
+        </li>
+      </ul>
       </aside>
 
       <div


### PR DESCRIPTION
issue:
https://github.com/BewlyBewly/BewlyBewly/issues/49
https://github.com/BewlyBewly/BewlyBewly/issues/428
https://github.com/BewlyBewly/BewlyBewly/issues/1162

提供一种在浏览器渲染有问题的前提下提供一种粗浅的暂时解决方案

基本就是将fliter单独分离到before中 仅对背景进行遮罩 在保证侧边栏背景模糊的情况下让前显字体正常展示
但是动画时字体的跳变只能通过更改触发动画和chrome什么时候把渲染逻辑改掉解决了（

改动前：
![屏幕截图 2024-12-03 190848](https://github.com/user-attachments/assets/12485ce0-461d-4218-9970-15dd10576204)
改动后：
![image](https://github.com/user-attachments/assets/fd3b5c48-3a5d-42a7-891c-b718530ac460)
