### PR TITLE
feat(dock): feat: open new tab via middle/ctrl/meta click

### DIFF
--- a/src/components/Dock/Dock.vue
+++ b/src/components/Dock/Dock.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
 // const emit = defineEmits(['pageChange', 'settingsVisibilityChange', 'refresh', 'backToTop'])
 const emit = defineEmits<{
   (e: 'dockItemClick', dockItem: DockItem): void
+  (e: 'dockItemMiddleClick', dockItem: DockItem): void
   (e: 'settingsVisibilityChange'): void
   (e: 'refresh'): void
   (e: 'backToTop'): void
@@ -131,6 +132,11 @@ function handleDockItemClick(dockItem: DockItem) {
   emit('dockItemClick', dockItem)
 }
 
+function handleDockItemMiddleClick(dockItem: DockItem) {
+  activatedDockItem.value = dockItem
+  emit('dockItemMiddleClick', dockItem)
+}
+
 function handleBackToTopOrRefresh() {
   if (reachTop.value)
     emit('refresh')
@@ -226,6 +232,7 @@ const dockTransformStyle = computed((): { transform: string, transformOrigin: st
                 'disable-glowing-effect': settings.disableDockGlowingEffect,
               }"
               @click="handleDockItemClick(dockItem)"
+              @click.middle="handleDockItemMiddleClick(dockItem)"
             >
               <div
                 v-show="!isDockItemActivated(dockItem)"

--- a/src/components/Dock/Dock.vue
+++ b/src/components/Dock/Dock.vue
@@ -9,7 +9,7 @@ import { AppPage } from '~/enums/appEnums'
 import { settings } from '~/logic'
 import type { DockItem } from '~/stores/mainStore'
 import { useMainStore } from '~/stores/mainStore'
-import { isHomePage } from '~/utils/main'
+import { isHomePage, openLinkToNewTab } from '~/utils/main'
 
 import Tooltip from '../Tooltip.vue'
 import type { HoveringDockItem } from './types'
@@ -127,14 +127,19 @@ function toggleHideDock(hide: boolean) {
     hideDock.value = false
 }
 
-function handleDockItemClick(dockItem: DockItem) {
+function handleDockItemClick($event: MouseEvent, dockItem: DockItem) {
+  if ($event.ctrlKey || $event.metaKey) {
+    openDockItemInNewTab(dockItem)
+    return
+  }
+
   activatedDockItem.value = dockItem
   emit('dockItemClick', dockItem)
 }
 
-function handleDockItemMiddleClick(dockItem: DockItem) {
+function openDockItemInNewTab(dockItem: DockItem) {
   activatedDockItem.value = dockItem
-  emit('dockItemMiddleClick', dockItem)
+  openLinkToNewTab(`https://www.bilibili.com/?page=${dockItem.page}`)
 }
 
 function handleBackToTopOrRefresh() {
@@ -231,8 +236,8 @@ const dockTransformStyle = computed((): { transform: string, transformOrigin: st
                 'inactive': hoveringDockItem.themeMode && isDark,
                 'disable-glowing-effect': settings.disableDockGlowingEffect,
               }"
-              @click="handleDockItemClick(dockItem)"
-              @click.middle="handleDockItemMiddleClick(dockItem)"
+              @click="handleDockItemClick($event, dockItem)"
+              @click.middle="openDockItemInNewTab(dockItem)"
             >
               <div
                 v-show="!isDockItemActivated(dockItem)"

--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -160,11 +160,6 @@ function handleDockItemClick(dockItem: DockItem) {
   }
 }
 
-function handleDockItemMiddleClick(dockItem: DockItem) {
-  openLinkToNewTab(`https://www.bilibili.com/?page=${dockItem.page}`);
-}
-
-
 function changeActivatePage(pageName: AppPage) {
   const osInstance = scrollbarRef.value?.osInstance()
   const scrollTop: number = osInstance.elements().viewport.scrollTop
@@ -314,7 +309,6 @@ provide<BewlyAppProvider>('BEWLY_APP', {
         @refresh="handleThrottledPageRefresh"
         @back-to-top="handleThrottledBackToTop"
         @dock-item-click="handleDockItemClick"
-        @dock-item-middle-click="handleDockItemMiddleClick"
       />
       <SideBar
         v-else

--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -160,6 +160,11 @@ function handleDockItemClick(dockItem: DockItem) {
   }
 }
 
+function handleDockItemMiddleClick(dockItem: DockItem) {
+  openLinkToNewTab(`https://www.bilibili.com/?page=${dockItem.page}`);
+}
+
+
 function changeActivatePage(pageName: AppPage) {
   const osInstance = scrollbarRef.value?.osInstance()
   const scrollTop: number = osInstance.elements().viewport.scrollTop
@@ -309,6 +314,7 @@ provide<BewlyAppProvider>('BEWLY_APP', {
         @refresh="handleThrottledPageRefresh"
         @back-to-top="handleThrottledBackToTop"
         @dock-item-click="handleDockItemClick"
+        @dock-item-middle-click="handleDockItemMiddleClick"
       />
       <SideBar
         v-else


### PR DESCRIPTION
增加了一个简单的功能，在不影响原功能的情况下，允许用户通过鼠标中键 Dock Item 快速在新标签页打开对应页面

不影响设置中自定义的新标签页打开设定，即：
- 如果开启了设置中对应 Dock 内容的`在新标签页打开`，则无论左键中键都会打开新标签页
- 如果未开启，则左键在当前页打开，中键在新标签页打开

<!-- see: https://github.com/BewlyBewly/BewlyBewly/blob/main/docs/CONTRIBUTING.md -->
<!-- We may not respond to your issue or PR. -->
<!-- We may close an issue or PR without much feedback. -->
