### PR TITLE
fix: refactor and remove redundant code

### DIFF
--- a/src/components/TopBar/components/FavoritesPop.vue
+++ b/src/components/TopBar/components/FavoritesPop.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { onMounted, reactive, ref, watch } from 'vue'
 
 import Empty from '~/components/Empty.vue'
 import Loading from '~/components/Loading.vue'

--- a/src/components/TopBar/components/MomentsPop.vue
+++ b/src/components/TopBar/components/MomentsPop.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
-import { onMounted, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import Empty from '~/components/Empty.vue'

--- a/src/components/TopBar/components/WatchLaterPop.vue
+++ b/src/components/TopBar/components/WatchLaterPop.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { onMounted, reactive, ref } from 'vue'
 
 import Empty from '~/components/Empty.vue'
 import Loading from '~/components/Loading.vue'

--- a/src/composables/useDark.ts
+++ b/src/composables/useDark.ts
@@ -27,7 +27,8 @@ export function useDark() {
     { immediate: true },
   )
 
-  onMounted(() => {
+  // use watchEffect instead of onMounted because onMounted is only aviailable in setup function
+  watchEffect(() => {
     // Because some shadow dom may not be loaded when the page has already loaded, we need to wait until the page is idle
     runWhenIdle(() => {
       if (isDark.value) {

--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -180,9 +180,10 @@ function handleDockItemClick(dockItem: DockItem) {
     }
     else {
       if (isHomePage()) {
-        nextTick(() => {
+        // Replace NextTick with setTimeout(200), otherwise osInstance in function 'changeActivatePage' will be undefined
+        setTimeout(() => {
           changeActivatePage(dockItem.page)
-        })
+        }, 200)
       }
       else {
         location.href = `https://www.bilibili.com/?page=${dockItem.page}`

--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -264,12 +264,9 @@ function openIframeDrawer(url: string) {
 async function haveScrollbar() {
   await nextTick()
   const osInstance = scrollbarRef.value?.osInstance()
-  // If the scrollbarRef is not ready, return false
-  if (osInstance) {
-    const { viewport } = osInstance.elements()
-    const { scrollHeight } = viewport // get scroll offset
-    return scrollHeight > window.innerHeight
-  }
+  const { viewport } = osInstance.elements()
+  const { scrollHeight } = viewport // get scroll offset
+  return scrollHeight > window.innerHeight
 }
 
 // In drawer video, watch btn className changed and post message to parent

--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -264,9 +264,12 @@ function openIframeDrawer(url: string) {
 async function haveScrollbar() {
   await nextTick()
   const osInstance = scrollbarRef.value?.osInstance()
-  const { viewport } = osInstance.elements()
-  const { scrollHeight } = viewport // get scroll offset
-  return scrollHeight > window.innerHeight
+  // If the scrollbarRef is not ready, return false
+  if (osInstance) {
+    const { viewport } = osInstance.elements()
+    const { scrollHeight } = viewport // get scroll offset
+    return scrollHeight > window.innerHeight
+  }
 }
 
 // In drawer video, watch btn className changed and post message to parent


### PR DESCRIPTION
1、auto-import度已經有咗，唔需要再引入

2、composables -> useDark 中使用 onMounted 會有 warning，可能係組件仲未掛載就執行咗生命週期（因為有幾個係動態導入嘅組件），換成 watchEffect 可以避免 warning

![image](https://github.com/user-attachments/assets/291319c4-4a71-4757-83ea-0e5af0f871de)

3、個 7 osInstance 擺 nextTick 入邊攞唔到，改用 setTimeout 先至可以穩定獲取到節點（src/contentScripts/views/App.vue  changeActivatePage）
![image](https://github.com/user-attachments/assets/5c049c8d-fff6-4166-a560-21744036f58e)
