### PR TITLE
fix(iframe-page): iframe cors

### DIFF
--- a/src/components/IframePage.vue
+++ b/src/components/IframePage.vue
@@ -27,7 +27,13 @@ onBeforeUnmount(() => {
 async function releaseIframeResources() {
   // Clear iframe content
   currentUrl.value = 'about:blank'
-  iframeRef.value?.contentWindow?.document.write('')
+  /**
+   * eg: When use 'iframeRef.value?.contentWindow?.document' of t.bilibili.com iframe on bilibili.com, there may be cross domain issues
+   * set the src to 'about:blank' to avoid this issue, it also can release the memory
+   */
+  if (iframeRef.value) {
+    iframeRef.value.src = 'about:blank'
+  }
   await nextTick()
   iframeRef.value?.contentWindow?.close()
 

--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -264,12 +264,9 @@ function openIframeDrawer(url: string) {
 async function haveScrollbar() {
   await nextTick()
   const osInstance = scrollbarRef.value?.osInstance()
-  // If the scrollbarRef is not ready, return false
-  if (osInstance) {
-    const { viewport } = osInstance.elements()
-    const { scrollHeight } = viewport // get scroll offset
-    return scrollHeight > window.innerHeight
-  }
+  const { viewport } = osInstance.elements()
+  const { scrollHeight } = viewport // get scroll offset
+  return scrollHeight > window.innerHeight
 }
 
 // In drawer video, watch btn className changed and post message to parent

--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -264,9 +264,12 @@ function openIframeDrawer(url: string) {
 async function haveScrollbar() {
   await nextTick()
   const osInstance = scrollbarRef.value?.osInstance()
-  const { viewport } = osInstance.elements()
-  const { scrollHeight } = viewport // get scroll offset
-  return scrollHeight > window.innerHeight
+  // If the scrollbarRef is not ready, return false
+  if (osInstance) {
+    const { viewport } = osInstance.elements()
+    const { scrollHeight } = viewport // get scroll offset
+    return scrollHeight > window.innerHeight
+  }
 }
 
 // In drawer video, watch btn className changed and post message to parent


### PR DESCRIPTION
譬如：從動態頁跳到主頁，會觸發清除 iframe document innerContent 嘅操作，但如果呢兩個頁面嘅 domain 唔同，去攞 iframe 嘅 document 會導致跨域問題。

而 iframeRef.value?.contentWindow?.document.write('') 原本嘅目的係確保內容被清空，釋放內存。 

我覺得可以直接將 src 設為about:blank，同樣可以達到釋放內容嘅目的，且可以解決跨域問題。

（建議嚟嘅，不一定準確）
（因為 branch 係從 main branch 切出來的 所以會有4個多餘嘅commit，但實際上乜都冇改，睇 files changed 就好🥲）

![image](https://github.com/user-attachments/assets/1e596b39-eb6a-4e60-8b5a-7076502cf506)
![image](https://github.com/user-attachments/assets/386dd0d3-071a-4008-a9d1-627692d9a518)
