### PR TITLE
fix(issues #1301): missing badge text

### DIFF
--- a/src/components/BangumiCard/BangumiCard.vue
+++ b/src/components/BangumiCard/BangumiCard.vue
@@ -57,7 +57,7 @@ const { isDark } = useDark()
         <div aspect="12/16" overflow-hidden rounded="$bew-radius">
           <!-- badge -->
           <div
-            v-if="bangumi.badge"
+            v-if="bangumi.badge && bangumi.badge.text"
             :style="{
               backgroundColor: isDark ? bangumi.badge.bgColorDark : bangumi.badge.bgColor,
             }"


### PR DESCRIPTION
[https://github.com/BewlyBewly/BewlyBewly/issues/1301](url)

接口並無返回  **text** 字段。呢種情況下，b 站係直接唔顯示 badge

![ff1a6f85f4c6839fecf9ddbeb9fed92f](https://github.com/user-attachments/assets/a7cf5bac-4164-4e1a-8619-9f2ffedce114)

![image](https://github.com/user-attachments/assets/73147492-b4d4-473e-be6f-c35342d2a415)