### PR TITLE
fix(bangumi-card): fix missing badge text (#1301)

### DIFF
--- a/src/components/BangumiCard/BangumiCard.vue
+++ b/src/components/BangumiCard/BangumiCard.vue
@@ -57,7 +57,7 @@ const { isDark } = useDark()
         <div aspect="12/16" overflow-hidden rounded="$bew-radius">
           <!-- badge -->
           <div
-            v-if="bangumi.badge"
+            v-if="bangumi.badge && bangumi.badge.text"
             :style="{
               backgroundColor: isDark ? bangumi.badge.bgColorDark : bangumi.badge.bgColor,
             }"


### PR DESCRIPTION
[#Issues 1301](https://github.com/BewlyBewly/BewlyBewly/issues/1301)

接口並無返回 text 字段。呢種情況下，b 站會直接唔顯示 badge

![image](https://github.com/user-attachments/assets/df9685ef-d8fc-4f3b-a93b-356b2cf4b99e)

![image](https://github.com/user-attachments/assets/2dc5157d-2069-4c07-b843-0a911a3c4d99)

