### PR TITLE
fix: resolve double scroll bar (#1262)

### DIFF
--- a/src/components/VideoCard/VideoCard.vue
+++ b/src/components/VideoCard/VideoCard.vue
@@ -169,12 +169,23 @@ function handleClick(event: MouseEvent) {
 }
 
 function handleMoreBtnClick(event: MouseEvent) {
+  // the distance between the bottom and the height of the more button
+  if (!moreBtnRef.value)
+    return
+  const { bottom, height } = moreBtnRef.value.getBoundingClientRect()
+
+  /**
+   * if (screen height - bottom > 400px) then context-menu offset upwards
+   * Why 400? Because the current context-menu is not a responsive layout, it can be temporarily referred to as 400
+   */
+  const offsetTop = window.innerHeight - bottom > 400 ? 0 : -400 - height
+
   showVideoOptions.value = false
   videoOptionsFloatingStyles.value = {
     position: 'absolute',
     top: 0,
     left: 0,
-    transform: `translate(${event.x}px, ${event.y}px)`,
+    transform: `translate(${event.x}px, ${event.y + offsetTop}px)`,
   }
   showVideoOptions.value = true
 }

--- a/src/components/VideoCard/VideoCard.vue
+++ b/src/components/VideoCard/VideoCard.vue
@@ -175,10 +175,10 @@ function handleMoreBtnClick(event: MouseEvent) {
   const { bottom, height } = moreBtnRef.value.getBoundingClientRect()
 
   /**
-   * if (screen height - bottom > 400px) then context-menu offset upwards
-   * Why 400? Because the current context-menu is not a responsive layout, it can be temporarily referred to as 400
+   * if (screen height - bottom > 406px) then context-menu offset upwards
+   * Why 406? Because the current context-menu is not a responsive layout, it can be temporarily referred to as 406
    */
-  const offsetTop = window.innerHeight - bottom > 400 ? 0 : -400 - height
+  const offsetTop = window.innerHeight - bottom > 406 ? 0 : -406 - height
 
   showVideoOptions.value = false
   videoOptionsFloatingStyles.value = {


### PR DESCRIPTION
[issue #1262](https://github.com/BewlyBewly/BewlyBewly/issues/1262)

導致出現多餘 scrollBar嘅原因係：context-menu 嘅高度已經超出瀏覽器底部

參照 B 站嘅交互效果，我哋可以加個判斷：當“瀏覽器高度  -  嗰粒制的底部到瀏覽器頂部嘅距離  >  context-menu 嘅高度” ，就由context-menu向上彈出

context-menu 高度主要受 li icon(em) 以及 padding(--bew-base-font-size)  嘅影響，我睇見暫時冇做自適應，所以可以用 406 嚟作為一個大概嘅高度

效果：
![image](https://github.com/user-attachments/assets/2acad5e6-d112-4af2-848f-c45985869ad1)

